### PR TITLE
Improve filtering and UI error handling

### DIFF
--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -161,7 +161,7 @@ class MainWindow(QMainWindow):
             try:
                 self.model._data.write_parquet(file_name)
             except Exception as e:
-                print(f"Error saving file: {e}")
+                QMessageBox.critical(self, "Save Error", f"Error saving file: {e}")
     
     def is_model_loaded(self):
         if not hasattr(self, 'model') or self.model is None:

--- a/src/app/widgets/edit_menu_gui.py
+++ b/src/app/widgets/edit_menu_gui.py
@@ -1,7 +1,7 @@
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QComboBox,
     QStackedWidget, QSpinBox, QDoubleSpinBox, QDateEdit, QDateTimeEdit,
-    QPushButton, QWidget, QListWidgetItem, QListWidget
+    QPushButton, QWidget, QListWidgetItem, QListWidget, QMessageBox
 )
 from PyQt6.QtCore import QDate, QDateTime
 


### PR DESCRIPTION
### Motivation
- Make UI error reporting visible to users instead of printing to stdout so failures are clearer and non-silent by using dialog boxes like `QMessageBox`.
- Ensure filters produce a properly-updated model and pagination state instead of mutating internal fields and manually recomputing pages.
- Add a missing `QMessageBox` import used by edit dialogs so warnings can be displayed without runtime errors.

### Description
- Added `QMessageBox` import to `src/app/widgets/edit_menu_gui.py` to enable dialog-based warnings.
- Replaced `print`-based save failure reporting in `save_parquet` with `QMessageBox.critical` in `src/app/main_window.py` to surface save errors to users.
- Reworked `apply_filter` in `src/logic/filters.py` to compute a `filtered_df` (instead of directly assigning to `model._data`), raise on unsupported operations, and call `model.update_data(filtered_df)` to refresh pagination and view; also removed the previous manual page-data refresh and the `model.save_state()` call.
- Consolidated error handling in `apply_filter` to use `QMessageBox.warning` for invalid input and filter application errors.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724f6cc3bc832cae051bb81053e8d6)